### PR TITLE
gcloud continuous deployment

### DIFF
--- a/src/tpf/lk_patch/interact.py
+++ b/src/tpf/lk_patch/interact.py
@@ -1469,6 +1469,7 @@ def show_skyview_widget(tpf, notebook_url=None, aperture_mask="empty", catalogs=
             width=640,
             height=600,
             tools="tap,box_zoom,wheel_zoom,reset",
+            fig_name="fig_tpf_skyview",
         )
 
         # Add a marker (cross) to indicate the coordinate of the target

--- a/src/tpf/lk_patch/interact.py
+++ b/src/tpf/lk_patch/interact.py
@@ -687,6 +687,8 @@ def _create_background_task(func, *args, **kwargs):
 async def async_parse_and_add_catalogs_figure_elements(
     catalogs, magnitude_limit, tpf, doc, fig_tpf, ui_ctr, message_selected_target, arrow_4_selected
 ):
+    tpf_label = f"TIC {tpf.meta.get('TICID')}, sector {tpf.meta.get('SECTOR')}"
+
     # 1. create provider instances from catalog specifications
     providers = []
     for catalog_spec in catalogs:
@@ -726,7 +728,9 @@ async def async_parse_and_add_catalogs_figure_elements(
         # https://docs.bokeh.org/en/latest/docs/user_guide/server/app.html#updating-from-unlocked-callbacks
 
         async def do_catalog_init_locked(result):
-            log.debug(f"do_catalog_init_locked() for {provider.label}: {len(result) if result is not None else None}")
+            log.debug(
+                f"do_catalog_init_locked() for {tpf_label} - {provider.label}: {len(result) if result is not None else None}"
+            )
             try:
                 renderer = add_catalog_figure_elements(
                     provider, result, tpf, fig_tpf, ui_ctr, message_selected_target, arrow_4_selected
@@ -778,7 +782,7 @@ async def async_parse_and_add_catalogs_figure_elements(
                     ),
                     LightkurveWarning,
                 )
-            log.debug(f"Scheduling do_catalog_init_locked() for {provider.label}.")
+            log.debug(f"Scheduling do_catalog_init_locked() for {tpf_label} - {provider.label}.")
             doc.add_next_tick_callback(partial(do_catalog_init_locked, result=result))
 
         return do_catalog_init_unlocked

--- a/src/tpf/lk_patch/interact.py
+++ b/src/tpf/lk_patch/interact.py
@@ -300,7 +300,7 @@ def get_lightcurve_y_limits(lc_source):
     return low - margin, high + margin
 
 
-def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
+def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None, fig_name="fig_lc"):
     """Make the lightcurve figure elements.
 
     Parameters
@@ -333,6 +333,7 @@ def make_lightcurve_figure_elements(lc, lc_source, ylim_func=None):
         tools="pan,wheel_zoom,box_zoom,tap,reset",
         toolbar_location="below",
         border_fill_color="whitesmoke",
+        name=fig_name,
     )
     fig.title.offset = -10
 

--- a/src/tpf/main.py
+++ b/src/tpf/main.py
@@ -500,7 +500,7 @@ Shift-Click to add to the selections. Ctrl-Shift-Click to remove from the select
         # enable box_zoom_tool by default
         try:
             # fig_lc is also used by ylim_func above
-            fig_lc = ui_body.children[0].children[0]  # hack: assuming the widgets layout returned by show_interact_widget()
+            fig_lc = ui_body.select_one({"name": "fig_lc"})
             box_zoom_tools = [t for t in fig_lc.toolbar.tools if isinstance(t, bokeh.models.BoxZoomTool)]
             fig_lc.toolbar.active_drag = box_zoom_tools[0] if len(box_zoom_tools) > 0 else "auto"
         except Exception as e:

--- a/src/tpf/main.py
+++ b/src/tpf/main.py
@@ -445,10 +445,33 @@ Shift-Click to add to the selections. Ctrl-Shift-Click to remove from the select
                 lc = lc - get_bkg_per_pixel_lc() * lc.meta["APERTURE_MASK"].sum()
             return lc.normalize() if in_flux_normalized.active else lc
 
+        # a reference to the Lc plot to be created below, used by ylim_func()
+        fig_lc = None
+
         def ylim_func(lc):
+            # note: if `fig_lc` has been created,
+            # use it to restrict the x-range of the LC
+            # so that when one zooms in, it'll automatically scale
+            # the y-range to the date range specified,
+            # avoiding cases that extreme outliers (e.g.,) scattered light
+            # continue to affect the default y-range once zoomed in
+            if fig_lc is not None:
+                lc_trunc = lc.truncate(fig_lc.x_range.start, fig_lc.x_range.end)
+                if len(lc_trunc) > 0:
+                    lc = lc_trunc
+
+            # default ymin / ymax based on the range of flux in the LC (possibly zoomed in),
+            # padding with some extra spacing
+            ymin = np.nanmin(lc.flux).value
+            ymax = np.nanmax(lc.flux).value
+            ymax += np.abs(ymax - ymin) * 0.1
+            ymin -= np.abs(ymax - ymin) * 0.1
+
+            # override ymin / ymax if user specifies explicit values
+            ymin = get_value_in_float(in_ymin, ymin)
+            ymax = get_value_in_float(in_ymax, ymax)
+
             unit = lc.flux.unit
-            ymin = get_value_in_float(in_ymin, np.nanmin(lc.flux).value)
-            ymax = get_value_in_float(in_ymax, np.nanmax(lc.flux).value)
             return (ymin * unit, ymax * unit)
 
         # for TessCut, set the initial aperture mask to be the single pixel where the target is located
@@ -462,7 +485,7 @@ Shift-Click to add to the selections. Ctrl-Shift-Click to remove from the select
         #     reflected when users changes the LC by selecting different pixels
         #     (without the need to click inspect button again)
 
-        create_tpf_interact_ui, interact_mask = show_interact_widget(
+        create_tpf_interact_ui_func, interact_mask = show_interact_widget(
             tpf,
             ylim_func=ylim_func,
             transform_func=transform_func,
@@ -471,11 +494,12 @@ Shift-Click to add to the selections. Ctrl-Shift-Click to remove from the select
             also_return_selection_mask=True,
         )
 
-        ui_body = await create_tpf_interact_ui()
+        ui_body = await create_tpf_interact_ui_func()
         ui_body.name = "tpf_interact_fig"
 
         # enable box_zoom_tool by default
         try:
+            # fig_lc is also used by ylim_func above
             fig_lc = ui_body.children[0].children[0]  # hack: assuming the widgets layout returned by show_interact_widget()
             box_zoom_tools = [t for t in fig_lc.toolbar.tools if isinstance(t, bokeh.models.BoxZoomTool)]
             fig_lc.toolbar.active_drag = box_zoom_tools[0] if len(box_zoom_tools) > 0 else "auto"

--- a/src/tpf/main.py
+++ b/src/tpf/main.py
@@ -383,7 +383,7 @@ def export_plt_fig_as_data_uri(fig, close_fig=True):
     return uri
 
 
-def create_tpf_interact_ui(tpf, hide_save_to_local_btn=True):
+def create_tpf_interact_ui(tpf, fig_tpf_skyview=None, hide_save_to_local_btn=True):
     btn_inspect = Button(label="Inspect", button_type="primary")
     btn_help_inspect = HelpButton(
         tooltip=Tooltip(
@@ -505,6 +505,12 @@ Shift-Click to add to the selections. Ctrl-Shift-Click to remove from the select
             fig_lc.toolbar.active_drag = box_zoom_tools[0] if len(box_zoom_tools) > 0 else "auto"
         except Exception as e:
             warnings.warn(f"Failed to enable box zoom as default for tpf.interact() LC viewer. {e}")
+
+        # use the x/y zoom range of the SkyView TPF as the default, if available
+        if fig_tpf_skyview is not None:
+            fig_tpf = ui_body.select_one({"name": "fig_tpf"})
+            fig_tpf.x_range = fig_tpf_skyview.x_range.clone()
+            fig_tpf.y_range = fig_tpf_skyview.y_range.clone()
 
         # hide "Save lightcurve" button (not applicable in Web UI)
         # OPEN: we might present a new button to let users download the LC from the webapp
@@ -846,7 +852,7 @@ async def create_app_body_ui_from_tpf(doc, tpf, magnitude_limit=None, catalogs=N
                     ztf_ngoodobsrel_min=ztf_ngoodobsrel_min,
                     skypatrol2_search_radius=skypatrol2_search_radius,
                 ),
-                create_tpf_interact_ui(tpf),
+                create_tpf_interact_ui(tpf, fig_tpf_skyview=skyview_ui.select_one({"name": "fig_tpf_skyview"})),
                 create_lc_viewer_ui(),
                 # the name is used to signify an interactive UI is returned
                 # (as opposed to the UI with a dummy UI or error message in the boundary conditions)


### PR DESCRIPTION
- tpf.interact(): auto-scale y-range of the LC, use the pixel range of SkyView as the default 
- Better error handling for case TIC not found in the specific sector
- better debug around scheduling of (bokeh locked) updates
- tpf_utils: optional params for download() (not exposed in webapp)
