### PR TITLE
gcloud continuous deployment

### DIFF
--- a/src/tpf/gcloud/assemble.sh
+++ b/src/tpf/gcloud/assemble.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 
 base=`dirname $0`
-dest=$1
+dest=$base/../../../build/tess-tpf
 
-if [ "$dest" == "" ]; then
-    dest=$base/../../../build/tess-tpf
+# the commit SHA
+# - in gcloud continuous deployment env, it will be supplied as a parameter
+#   (git not available in gcloud's bash build step)
+# - in local build, we generates it locally
+commit_sha=$1
+if [ "$commit_sha" == "" ]; then
+  commit_sha=`git rev-parse HEAD`
+  echo To save commit SHA in build: $commit_sha
 fi
 
 set -e
@@ -27,7 +33,7 @@ cp --update --archive  $base/.*  $dest
 rm -f $dest/cloudbuild.yaml
 
 # save commit SHA to be displayed in the UI.
-git rev-parse HEAD > $dest/tpf/build.txt
+echo $commit_sha > $dest/tpf/build.txt
 
 ls -l $dest/ $dest/tpf
 

--- a/src/tpf/gcloud/cloudbuild.yaml
+++ b/src/tpf/gcloud/cloudbuild.yaml
@@ -5,10 +5,11 @@ steps:
   # First assemble the sources and artifacts at ./build/tess-tpf
   # the script somehow lost the x attribute after copied to gcloud build,
   # so we have to re-add it.
+  # Pass git commit SHA to assemble.sh so that it can be saved in the build.
   - name: 'bash'
     script: chmod a+x ./src/tpf/gcloud/assemble.sh
   - name: 'bash'
-    args: ['./src/tpf/gcloud/assemble.sh']
+    script: ./src/tpf/gcloud/assemble.sh $COMMIT_SHA
 
   # The rest is based on gcloud continuous deployment's default config,
   # except the build base dir is ./build/tess-tpf instead of .


### PR DESCRIPTION
save git commit SHA in gcloud continuous deployment env
- workaround gcloud bash builder does not have git installed.
