### PR TITLE
gcloud continuous deployment

### DIFF
--- a/src/tpf/gcloud/assemble.sh
+++ b/src/tpf/gcloud/assemble.sh
@@ -3,6 +3,8 @@
 base=`dirname $0`
 dest=$base/../../../build/tess-tpf
 
+set -e
+
 # the commit SHA
 # - in gcloud continuous deployment env, it will be supplied as a parameter
 #   (git not available in gcloud's bash build step)
@@ -12,8 +14,6 @@ if [ "$commit_sha" == "" ]; then
   commit_sha=`git rev-parse HEAD`
   echo To save commit SHA in build: $commit_sha
 fi
-
-set -e
 
 # first clean the destination dir to ensure a clean build
 if [ -d "$dest" ]; then

--- a/src/tpf/gcloud/cloudbuild.yaml
+++ b/src/tpf/gcloud/cloudbuild.yaml
@@ -10,6 +10,7 @@ steps:
     script: chmod a+x ./src/tpf/gcloud/assemble.sh
   - name: 'bash'
     script: ./src/tpf/gcloud/assemble.sh $COMMIT_SHA
+    automapSubstitutions: true
 
   # The rest is based on gcloud continuous deployment's default config,
   # except the build base dir is ./build/tess-tpf instead of .


### PR DESCRIPTION
try to make COMMIT_SHA available in gcloud bash build step
