### PR TITLE
gcloud continuous deployment

### DIFF
--- a/src/tpf/lk_patch/interact_sky_providers/vsx.py
+++ b/src/tpf/lk_patch/interact_sky_providers/vsx.py
@@ -184,6 +184,7 @@ def _parse_response(result):
 
 
 # VSX API documentation: https://www.aavso.org/apis-aavso-resources#:~:text=The%20VSX%20API%20is%20not%20%22official%22%20yet
+# VSX hostname change in Jan 2025: https://github.com/AAVSO/VStar/issues/458
 # See also VSX in Vizier : https://vizier.cds.unistra.fr/viz-bin/VizieR-3?-source=B/vsx/vsx
 @lru_cache
 def _query_cone_region(ra2000, dec2000, radius_deg, magnitude_limit=None):
@@ -191,7 +192,7 @@ def _query_cone_region(ra2000, dec2000, radius_deg, magnitude_limit=None):
     The result is formatted to be compatible with Vizier in VSX (`B/vsx/vsx`) to the extent possible.
     """
 
-    query_url = f"https://www.aavso.org/vsx/index.php?view=api.list&ra={ra2000}&dec={dec2000}&radius={radius_deg}&format=json"
+    query_url = f"https://vsx.aavso.org/index.php?view=api.list&ra={ra2000}&dec={dec2000}&radius={radius_deg}&format=json"
     if magnitude_limit is not None:
         query_url += f"&tomag={magnitude_limit}"
 
@@ -344,7 +345,7 @@ class VSXInteractSkyCatalogProvider(InteractSkyCatalogProvider):
         ]
 
     def get_detail_view(self, data: dict) -> Tuple[dict, list]:
-        vsx_url = f"https://www.aavso.org/vsx/index.php?view=detail.top&oid={data['OID']}"
+        vsx_url = f"https://vsx.aavso.org/index.php?view=detail.top&oid={data['OID']}"
         if np.isnan(data["Epoch"]):
             epoch_text = ""
         else:

--- a/src/tpf/tpf_utils.py
+++ b/src/tpf/tpf_utils.py
@@ -101,7 +101,7 @@ def _do_download_tesscut(sr, download_kwargs=None):
     return tpf
 
 
-async def get_tpf(tic, sector, msg_label, search_kwargs=None, download_kwargs=None):
+async def get_tpf(tic, sector, msg_label, search_sources=None, search_kwargs=None, download_kwargs=None):
     # suppress the unnecessary logging error messages "No data found for target ..." from search
     # they just pollute the log output in an webapp environment
     search_log = lk.search.log
@@ -114,15 +114,29 @@ async def get_tpf(tic, sector, msg_label, search_kwargs=None, download_kwargs=No
 
     search_log.error = error_ignore_no_data
     try:
-        return await _do_get_tpf(tic, sector, msg_label, search_kwargs=search_kwargs, download_kwargs=download_kwargs)
+        return await _do_get_tpf(
+            tic, sector, msg_label, search_sources=search_sources, search_kwargs=search_kwargs, download_kwargs=download_kwargs
+        )
     finally:
         search_log.error = error_original
 
 
-async def _do_get_tpf(tic, sector, msg_label, search_kwargs=None, download_kwargs=None):
+async def _do_get_tpf(tic, sector, msg_label, search_sources=None, search_kwargs=None, download_kwargs=None):
+    if search_sources is None or search_sources == "all":
+        to_search_tpf, to_search_tesscut = True, True
+    elif search_sources == "tpf":
+        to_search_tpf, to_search_tesscut = True, False
+    elif search_sources == "tesscut":
+        to_search_tpf, to_search_tesscut = False, True
+    else:
+        raise ValueError(f"Invalid search_sources: {search_sources}")
 
     @timed()
     def do_search_tpf():
+        if not to_search_tpf:
+            log.debug("do_search_tpf() skipped due to user override")
+            return lk.SearchResult()
+
         search_kwargs_actual = search_kwargs if search_kwargs is not None else dict()
 
         sr = search_targetpixelfile(f"TIC{tic}", mission="TESS", sector=sector, **search_kwargs_actual)
@@ -137,6 +151,9 @@ async def _do_get_tpf(tic, sector, msg_label, search_kwargs=None, download_kwarg
 
     @timed()
     def do_search_tesscut():
+        if not to_search_tesscut:
+            log.debug("do_search_tesscut() skipped due to user override")
+            return lk.SearchResult()
         sr = search_tesscut(f"TIC{tic}", sector=sector)
         return sr
 
@@ -144,6 +161,9 @@ async def _do_get_tpf(tic, sector, msg_label, search_kwargs=None, download_kwarg
     def do_fast_search_tesscut():
         # timing it is somewhat useless as it's almost instantaneous
         # but it makes the timing log more uniform.
+        if not to_search_tesscut:
+            log.debug("do_fast_search_tesscut() skipped due to user override")
+            return lk.SearchResult()
         sr = fast_search_tesscut(f"TIC{tic}", sector=sector)
         return sr
 


### PR DESCRIPTION
- use updated VSX hostname
- optional params for `get_tpf()` (used by notebook, irrelevant to webapp)
